### PR TITLE
Convert GH-Importer-lab/pipelines/pipeline1 to GitHub Actions

### DIFF
--- a/.github/workflows/pipeline1.yml
+++ b/.github/workflows/pipeline1.yml
@@ -1,0 +1,17 @@
+name: GH-Importer-lab/pipelines/pipeline1
+on:
+  push:
+    branches:
+    - main
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.3.0
+    - name: Run a one-line script
+      run: echo Hello, I am pipeline 1!
+    - name: Run a multi-line script
+      run: |-
+        echo Add other tasks to build, test, and deploy your project.
+        echo See https://aka.ms/yaml


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/foodeater/GH-Importer-lab/_build?definitionId=2) :tada: